### PR TITLE
use pg.connect directly for connection pooling purposes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,7 @@ var gatepost = require('gatepost');
 var pg = require('pg');
 var joi = require('joi');
 
-var client = new pg.Client('postgres://fritzy@localhost/fritzy');
-gatepost.registerPG(client);
+gatepost.setConnection('postgres://fritzy@localhost/fritzy');
 
 var Book = new gatepost.Model({
     id: {type: 'integer', primary: true},
@@ -120,6 +119,6 @@ __callback signature__
 
 The results are an array of model instances, or a single model if `oneResult` was set to true (null if no results).
  
-### registerPG
+### setConnection
 
- Register the `pg` postgres client with gatepost to use for queries.
+ Configure the `pg` postgres client with gatepost to use for queries. Accepts anything valid in the first parameter of [pg.connect](https://github.com/brianc/node-postgres/wiki/pg#parameters).


### PR DESCRIPTION
since passing in an instance of `pg.Client` directly prevents pooling, I tweaked things so instead you pass in your connection information and gatepost will call `pg.connect` to acquire a client within the pool and patch it on the fly if necessary. only real change is that `getDB` is now an asynchronous function.
