### PR TITLE
Don't run query method if arg validation fails.

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,11 @@ Model.prototype = Object.create(verymodel.VeryModel.prototype);
     opts = this.prepOpts(opts);
     this[opts.name] = (args, callback) => {
       let config = prepArgs(args, callback, opts, this);
-      let query = prepQuery(opts.sql, config.args, null, this, opts.name);
+      let query;
+
+      if (!opts.validationError) {
+        query = prepQuery(opts.sql, config.args, null, this, opts.name);
+      }
       return this.runQuery(opts, query, config.callback);
     };
   };
@@ -163,10 +167,14 @@ Model.prototype = Object.create(verymodel.VeryModel.prototype);
     extension[opts.name] = function (args, callback) {
       let config = prepArgs(args, callback, opts);
       let errors = this.doValidate();
+      let query;
       if (errors.error !== null) {
         opts.validationError = errors.error;
       }
-      let query = prepQuery(opts.sql, config.args, this, this.__verymeta.model, `inst-${opts.name}`);
+
+      if (!opts.validationError) {
+        query = prepQuery(opts.sql, config.args, this, this.__verymeta.model, `inst-${opts.name}`);
+      }
       return this.__verymeta.model.runQuery(opts, query, config.callback);
     };
     this.extendModel(extension);


### PR DESCRIPTION
The sql method can reasonably expect not to be called with invalid parameters,
this fixes it such that sql() is not called if validation of args failed
